### PR TITLE
fix: point social share image to existing interview-guide.png

### DIFF
--- a/interview.html
+++ b/interview.html
@@ -35,11 +35,11 @@
     <meta property="og:site" content="https://juliocasal.com" />
     <meta property="og:title" content="The .NET Interview Prep Guide | Julio Casal" />
     <meta property="og:description" content="125 real questions from senior .NET interviews — with complete answers. Free PDF." />
-    <meta property="og:image" content="https://juliocasal.com/images/dotnet-interview-prep-guide.jpg" />
+    <meta property="og:image" content="https://juliocasal.com/images/interview-guide.png" />
     <meta property="og:url" content="https://juliocasal.com/interview" />
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="https://juliocasal.com/images/dotnet-interview-prep-guide.jpg">
-    <meta name="thumbnail" content="https://juliocasal.com/images/dotnet-interview-prep-guide.jpg" />
+    <meta name="twitter:image" content="https://juliocasal.com/images/interview-guide.png">
+    <meta name="thumbnail" content="https://juliocasal.com/images/interview-guide.png" />
 
     <!-- Webpage Title -->
     <title>The .NET Interview Prep Guide | Julio Casal</title>


### PR DESCRIPTION
## Problem
The og:image, twitter:image, and thumbnail meta tags on /interview.html were referencing images/dotnet-interview-prep-guide.jpg which does not exist in the repo. Social share previews showed no thumbnail.

## Fix
Updated all three meta tags to point to images/interview-guide.png (the actual existing file).