### PR TITLE
feat: add /interview-guide-download page for broadcast email

### DIFF
--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -498,10 +498,6 @@
                 </div>
             </div>
 
-            <!-- No Thanks (top) -->
-            <div class="no-thanks-wrap">
-                <a href="https://forms.microsoft.com/r/Qe5GefxGXx" target="_blank" class="btn-no-thanks">No Thanks, I don't want a discount</a>
-            </div>
         </div>
     </header>
 
@@ -1074,11 +1070,7 @@
                 </div>
             </div>
 
-            <!-- No Thanks (bottom) -->
-            <div class="no-thanks-wrap">
-                <a href="https://forms.microsoft.com/r/Qe5GefxGXx" target="_blank" class="btn-no-thanks">No Thanks, I don't want a discount</a>
-            </div>
-        </div>
+                    </div>
     </div>
 
     <!-- Copyright -->

--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -35,7 +35,7 @@
     <meta property="og:title" content="Interview Guide Sent! | Julio Casal" />
     <meta property="og:description" content="Your .NET Interview Prep Guide is on its way. Upgrade your skills now." />
     <meta property="og:image" content="https://juliocasal.com/images/interview-guide.png" />
-    <meta property="og:url" content="https://juliocasal.com/interview-guide-sent-subscribers" />
+    <meta property="og:url" content="https://juliocasal.com/interview-guide-download" />
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="https://juliocasal.com/images/interview-guide.png">
 

--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -1050,6 +1050,7 @@
                             <a href="https://learn.dotnetacademy.io/enroll/3712862?price_id=4662654&coupon=GUIDE124" class="bottom-cta-btn">
                                 Get the Interview Prep Bundle for $197
                             </a>
+                            <div style="font-size:0.78rem;color:rgba(255,255,255,0.5);margin-top:0.6rem;">Offer expires <span style="color:#f5a623;font-weight:600;">Sunday, March 22 at midnight.</span></div>
                         </div>
 
                         <!-- Bootcamp CTA -->
@@ -1064,6 +1065,7 @@
                             <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="bottom-cta-btn gold">
                                 Get the Full Bootcamp for $297
                             </a>
+                            <div style="font-size:0.78rem;color:rgba(255,255,255,0.5);margin-top:0.6rem;">Offer expires <span style="color:#f5a623;font-weight:600;">Sunday, March 22 at midnight.</span></div>
                         </div>
 
                     </div>

--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -426,7 +426,7 @@
                     <a href="https://attachments.convertkitcdnn2.com/645794/271c87b3-12ca-4c0c-b70d-0e5caadc87ed/the-dot-net-interview-prep-guide.pdf?utm_campaign=Interview+Guide+Broadcast&utm_medium=email&utm_source=kit" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
                         <i class="fas fa-download mr-2"></i> Download Your Free Guide
                     </a>
-                    <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here, a one-time offer just for you. Expires Sunday, March 22 at midnight. 👇</p>
+                    <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here, a one-time offer just for you. Expires <span style="color: #f5a623; font-weight: 600;">Sunday, March 22 at midnight.</span> 👇</p>
                 </div>
             </div>
 
@@ -444,7 +444,7 @@
                             <div class="price-row">
                                 <span class="price-original">$321</span>
                                 <span class="price-oto"><sup>$</sup>197</span>
-                                <div class="price-note">Offer expires Sunday, March 22 at midnight.</div>
+                                <div class="price-note">Offer expires <span style="color: #f5a623; font-weight: 600;">Sunday, March 22 at midnight.</span></div>
                             </div>
                             <!-- #1 — fixed height so boxes are visually comparable -->
                             <img src="images/bootcamp/aspnet-bundle-boxes.png" alt=".NET Interview Prep Bundle" class="bundle-image" style="max-width:75%;">
@@ -471,7 +471,7 @@
                             <div class="price-row">
                                 <span class="price-original">$497</span>
                                 <span class="price-oto"><sup>$</sup>297</span>
-                                <div class="price-note">Offer expires Sunday, March 22 at midnight.</div>
+                                <div class="price-note">Offer expires <span style="color: #f5a623; font-weight: 600;">Sunday, March 22 at midnight.</span></div>
                             </div>
                             <img src="images/bootcamp-bundle-boxes.png" alt=".NET Backend Developer Bootcamp" class="bundle-image">
                             <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="cta-btn">

--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -426,7 +426,7 @@
                     <a href="https://attachments.convertkitcdnn2.com/645794/271c87b3-12ca-4c0c-b70d-0e5caadc87ed/the-dot-net-interview-prep-guide.pdf?utm_campaign=Interview+Guide+Broadcast&utm_medium=email&utm_source=kit" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
                         <i class="fas fa-download mr-2"></i> Download Your Free Guide
                     </a>
-                    <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here, a one-time offer just for you 👇</p>
+                    <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here, a one-time offer just for you. Expires Sunday, March 22 at midnight. 👇</p>
                 </div>
             </div>
 
@@ -444,7 +444,7 @@
                             <div class="price-row">
                                 <span class="price-original">$321</span>
                                 <span class="price-oto"><sup>$</sup>197</span>
-                                <div class="price-note">One-time offer. Not available anywhere else.</div>
+                                <div class="price-note">Offer expires Sunday, March 22 at midnight.</div>
                             </div>
                             <!-- #1 — fixed height so boxes are visually comparable -->
                             <img src="images/bootcamp/aspnet-bundle-boxes.png" alt=".NET Interview Prep Bundle" class="bundle-image" style="max-width:75%;">
@@ -471,7 +471,7 @@
                             <div class="price-row">
                                 <span class="price-original">$497</span>
                                 <span class="price-oto"><sup>$</sup>297</span>
-                                <div class="price-note">One-time offer. Not available anywhere else.</div>
+                                <div class="price-note">Offer expires Sunday, March 22 at midnight.</div>
                             </div>
                             <img src="images/bootcamp-bundle-boxes.png" alt=".NET Backend Developer Bootcamp" class="bundle-image">
                             <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="cta-btn">

--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -421,12 +421,12 @@
                         Your .NET Interview Prep Guide Is Here! 🚀
                     </h1>
                     <h2 class="text-white mb-4" style="font-size: 1.65rem; font-weight: 400; opacity: 0.9;">
-                        125 essential questions for Senior &amp; Staff .NET interviews — with complete answers.
+                        125 essential questions for Senior &amp; Staff .NET interviews, with complete answers.
                     </h2>
                     <a href="https://attachments.convertkitcdnn2.com/645794/271c87b3-12ca-4c0c-b70d-0e5caadc87ed/the-dot-net-interview-prep-guide.pdf?utm_campaign=Interview+Guide+Broadcast&utm_medium=email&utm_source=kit" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
                         <i class="fas fa-download mr-2"></i> Download Your Free Guide
                     </a>
-                    <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here — a one-time offer just for you 👇</p>
+                    <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here, a one-time offer just for you 👇</p>
                 </div>
             </div>
 

--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -32,14 +32,14 @@
 
     <meta property="og:site_name" content="Julio Casal" />
     <meta property="og:site" content="https://juliocasal.com" />
-    <meta property="og:title" content="Interview Guide Sent! | Julio Casal" />
+    <meta property="og:title" content=".NET Interview Prep Guide | Julio Casal" />
     <meta property="og:description" content="Your .NET Interview Prep Guide is on its way. Upgrade your skills now." />
     <meta property="og:image" content="https://juliocasal.com/images/interview-guide.png" />
     <meta property="og:url" content="https://juliocasal.com/interview-guide-download" />
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="https://juliocasal.com/images/interview-guide.png">
 
-    <title>Interview Guide Sent!</title>
+    <title>.NET Interview Prep Guide Download</title>
 
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
     <link href="css/bootstrap.css" rel="stylesheet">

--- a/interview-guide-sent-subscribers.html
+++ b/interview-guide-sent-subscribers.html
@@ -1,0 +1,1098 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!-- Fathom - beautiful, simple website analytics -->
+    <script src="https://cdn.usefathom.com/script.js" data-site="LWAWGOWE" defer></script>
+    <!-- / Fathom -->
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-GKWPQFHL1Y"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-GKWPQFHL1Y');
+    </script>
+
+    <script type="text/javascript">
+        (function (c, l, a, r, i, t, y) {
+            c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };
+            t = l.createElement(r); t.async = 1; t.src = "https://www.clarity.ms/tag/" + i;
+            y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+        })(window, document, "clarity", "script", "mzlifzd36i");
+    </script>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <meta name="description" content="Your .NET Interview Prep Guide is on its way. Upgrade your .NET skills with the full training package.">
+    <meta name="author" content="Julio Casal">
+    <meta name="robots" content="noindex">
+
+    <meta property="og:site_name" content="Julio Casal" />
+    <meta property="og:site" content="https://juliocasal.com" />
+    <meta property="og:title" content="Interview Guide Sent! | Julio Casal" />
+    <meta property="og:description" content="Your .NET Interview Prep Guide is on its way. Upgrade your skills now." />
+    <meta property="og:image" content="https://juliocasal.com/images/interview-guide.png" />
+    <meta property="og:url" content="https://juliocasal.com/interview-guide-sent-subscribers" />
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="https://juliocasal.com/images/interview-guide.png">
+
+    <title>Interview Guide Sent!</title>
+
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+    <link href="css/bootstrap.css" rel="stylesheet">
+    <link href="css/fontawesome-all.css" rel="stylesheet">
+    <link href="css/styles.css" rel="stylesheet">
+
+    <link rel="icon">
+
+    <style>
+        body {
+            background: #1a1a2e !important;
+            min-height: 100vh;
+        }
+
+        .header { background-color: #1a1a2e !important; }
+        .copyright { background-color: #1a1a2e !important; }
+
+        /* ── Pricing Cards ──────────────────────────────────── */
+        .pricing-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1.5rem;
+            align-items: start;
+        }
+
+        @media (max-width: 768px) {
+            .pricing-grid { grid-template-columns: 1fr; }
+        }
+
+        .pricing-card {
+            background: linear-gradient(135deg, rgba(103, 126, 234, 0.18) 0%, rgba(118, 75, 162, 0.18) 100%);
+            border: 2px solid rgba(103, 126, 234, 0.35);
+            border-radius: 20px;
+            padding: 2rem 1.75rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            text-align: center;
+            transition: all 0.3s ease;
+        }
+
+        .pricing-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 12px 40px rgba(103, 126, 234, 0.25);
+        }
+
+        /* Best deal: gold/amber accent — more readable, feels premium */
+        .pricing-card.best-deal {
+            border-color: rgba(245, 166, 35, 0.6);
+            background: linear-gradient(135deg, rgba(245, 166, 35, 0.1) 0%, rgba(240, 120, 10, 0.1) 100%);
+            position: relative;
+        }
+
+        .pricing-card.best-deal:hover {
+            box-shadow: 0 12px 40px rgba(245, 166, 35, 0.25);
+        }
+
+        .best-deal-badge {
+            position: absolute;
+            top: -15px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: linear-gradient(45deg, #f5a623 0%, #f0860a 100%);
+            color: white;
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            padding: 0.3rem 1.2rem;
+            border-radius: 20px;
+            white-space: nowrap;
+            box-shadow: 0 3px 10px rgba(245, 166, 35, 0.4);
+        }
+
+        .pricing-card .bundle-name {
+            color: white;
+            font-size: 1.3rem;
+            font-weight: 700;
+            margin-bottom: 0.2rem;
+        }
+
+        /* #3 — course count subtitle */
+        .pricing-card .course-count {
+            font-size: 0.82rem;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.55);
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            margin-bottom: 1rem;
+        }
+
+        .pricing-card .price-row { margin-bottom: 1.25rem; }
+
+        .pricing-card .price-original {
+            color: rgba(255,255,255,0.45);
+            font-size: 1rem;
+            text-decoration: line-through;
+            margin-right: 0.4rem;
+        }
+
+        .pricing-card .price-oto {
+            font-size: 2.1rem;
+            font-weight: 800;
+            color: white;
+        }
+
+        .pricing-card .price-oto sup {
+            font-size: 1.1rem;
+            vertical-align: super;
+        }
+
+        .pricing-card .price-note {
+            font-size: 0.78rem;
+            color: rgba(255,255,255,0.5);
+            margin-top: 0.25rem;
+        }
+
+        /* #1 — both images same height so boxes look comparable */
+        .pricing-card .bundle-image {
+            width: 100%;
+            height: 200px;
+            object-fit: contain;
+            margin-bottom: 1.25rem;
+        }
+
+        /* CTA buttons inside pricing cards */
+        .pricing-card .cta-btn {
+            background: linear-gradient(45deg, #667eea 0%, #764ba2 100%);
+            border: none;
+            padding: 0.9rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 700;
+            border-radius: 50px;
+            color: white;
+            text-decoration: none;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            display: block;
+            margin-bottom: 1.5rem;
+            width: 100%;
+            line-height: 1.4;
+        }
+
+        .pricing-card.best-deal .cta-btn {
+            background: linear-gradient(45deg, #f5a623 0%, #f0860a 100%);
+        }
+
+        .pricing-card .cta-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(103, 126, 234, 0.4);
+            color: white;
+            text-decoration: none;
+        }
+
+        .pricing-card.best-deal .cta-btn:hover {
+            box-shadow: 0 6px 20px rgba(245, 166, 35, 0.4);
+        }
+
+        /* ── Include list ───────────────────────────────────── */
+        .include-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            text-align: left;
+            width: 100%;
+        }
+
+        .include-list li {
+            color: rgba(255,255,255,0.88);
+            font-size: 0.88rem;
+            padding: 0.3rem 0;
+            display: flex;
+            align-items: flex-start;
+            gap: 0.6rem;
+        }
+
+        .include-list li .li-icon {
+            flex-shrink: 0;
+            width: 1.1rem;
+            text-align: center;
+            margin-top: 2px;
+        }
+
+        /* ── No Thanks ──────────────────────────────────────── */
+        .no-thanks-wrap {
+            text-align: center;
+            padding: 1.5rem 0 2rem;
+        }
+
+        .btn-no-thanks {
+            display: inline-block;
+            border: 2px solid rgba(255,255,255,0.3);
+            color: rgba(255,255,255,0.55);
+            padding: 0.65rem 2.2rem;
+            border-radius: 50px;
+            font-size: 0.9rem;
+            font-weight: 600;
+            text-decoration: none;
+            transition: all 0.2s ease;
+        }
+
+        .btn-no-thanks:hover {
+            border-color: rgba(255,255,255,0.55);
+            color: rgba(255,255,255,0.85);
+            text-decoration: none;
+            background-color: rgba(255,255,255,0.06);
+        }
+
+        /* ── Feature cards ──────────────────────────────────── */
+        .benefit-card {
+            background: linear-gradient(135deg, rgba(103, 126, 234, 0.18) 0%, rgba(118, 75, 162, 0.18) 100%);
+            border: 2px solid rgba(103, 126, 234, 0.3);
+            border-radius: 16px;
+            padding: 1.25rem 1.25rem 1.25rem 1.25rem;
+            transition: all 0.3s ease;
+            margin-bottom: 1.25rem;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .benefit-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 10px 30px rgba(103, 126, 234, 0.2);
+        }
+
+        /* #4 — Bootcamp-only cards: gold/amber left stripe + label banner */
+        .benefit-card.bootcamp-only {
+            border-color: rgba(245, 166, 35, 0.4);
+            background: linear-gradient(135deg, rgba(245, 166, 35, 0.08) 0%, rgba(240, 120, 10, 0.08) 100%);
+            border-left: 4px solid rgba(245, 166, 35, 0.7);
+            padding-bottom: 2.5rem; /* room for the absolute-positioned badge */
+        }
+
+        .benefit-card.bootcamp-only:hover {
+            box-shadow: 0 10px 30px rgba(245, 166, 35, 0.18);
+        }
+
+        .benefit-card .media {
+            display: flex;
+            align-items: flex-start;
+        }
+
+        .benefit-card h5 {
+            color: white;
+            font-size: 1rem;
+            margin-bottom: 0.4rem;
+            line-height: 1.4;
+        }
+
+        .benefit-card p {
+            color: rgba(255,255,255,0.82);
+            font-size: 0.87rem;
+            margin-bottom: 0;
+            line-height: 1.55;
+        }
+
+        /* Bootcamp badge — absolute bottom-right corner */
+        .bootcamp-tag {
+            position: absolute;
+            bottom: 0.75rem;
+            right: 0.85rem;
+            background: linear-gradient(45deg, #f5a623 0%, #f0860a 100%);
+            color: white;
+            font-size: 0.62rem;
+            font-weight: 700;
+            letter-spacing: 0.07em;
+            text-transform: uppercase;
+            padding: 0.2rem 0.65rem;
+            border-radius: 8px;
+        }
+
+        /* ── Section heading ──────────────────────────────── */
+        .section-label {
+            text-align: center;
+            color: rgba(255,255,255,0.6);
+            font-size: 0.82rem;
+            font-weight: 600;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            margin-bottom: 0.4rem;
+        }
+
+        .section-title {
+            text-align: center;
+            color: white;
+            font-size: 1.85rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+        }
+
+        /* Legend */
+        .legend-row {
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+            flex-wrap: wrap;
+            margin-bottom: 2rem;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: rgba(255,255,255,0.7);
+            font-size: 0.85rem;
+        }
+
+        .legend-swatch {
+            width: 28px;
+            height: 14px;
+            border-radius: 4px;
+            flex-shrink: 0;
+        }
+
+        .legend-swatch.both {
+            background: linear-gradient(135deg, rgba(103,126,234,0.7), rgba(118,75,162,0.7));
+            border: 1px solid rgba(103,126,234,0.7);
+        }
+
+        .legend-swatch.bootcamp {
+            background: linear-gradient(45deg, #f5a623, #f0860a);
+            border-left: 4px solid rgba(245,166,35,0.9);
+        }
+
+        /* ── Bottom CTA cards ─────────────────────────────── */
+        .bottom-cta-card {
+            background: linear-gradient(135deg, rgba(103, 126, 234, 0.15) 0%, rgba(118, 75, 162, 0.15) 100%);
+            border: 2px solid rgba(103, 126, 234, 0.3);
+            border-radius: 16px;
+            padding: 1.75rem 1.5rem;
+            text-align: center;
+        }
+
+        .bottom-cta-card.best-deal {
+            border-color: rgba(245, 166, 35, 0.5);
+            background: linear-gradient(135deg, rgba(245, 166, 35, 0.1) 0%, rgba(240, 120, 10, 0.08) 100%);
+        }
+
+        .bottom-cta-btn {
+            display: block;
+            width: 100%;
+            background: linear-gradient(45deg, #667eea 0%, #764ba2 100%);
+            border: none;
+            padding: 0.9rem 1rem;
+            font-size: 0.95rem;
+            font-weight: 700;
+            border-radius: 50px;
+            color: white;
+            text-decoration: none;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            line-height: 1.4;
+            margin-top: 0.75rem;
+        }
+
+        .bottom-cta-btn.gold {
+            background: linear-gradient(45deg, #f5a623 0%, #f0860a 100%);
+        }
+
+        .bottom-cta-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(103, 126, 234, 0.4);
+            color: white;
+            text-decoration: none;
+        }
+
+        .bottom-cta-btn.gold:hover {
+            box-shadow: 0 6px 20px rgba(245, 166, 35, 0.4);
+        }
+    </style>
+</head>
+
+<body data-spy="scroll" data-target=".fixed-top">
+
+    <!-- Header / Hero -->
+    <header id="header" class="header" style="padding: 2.5rem 0 1rem;">
+        <div class="container">
+            <div class="row justify-content-center mb-5">
+                <div class="col-lg-10 text-center">
+                    <h1 class="text-white mb-3" style="font-size: 2.5rem; font-weight: 700;">
+                        Your .NET Interview Prep Guide Is Here! 🚀
+                    </h1>
+                    <h2 class="text-white mb-4" style="font-size: 1.65rem; font-weight: 400; opacity: 0.9;">
+                        125 essential questions for Senior &amp; Staff .NET interviews — with complete answers.
+                    </h2>
+                    <a href="https://juliocasal.com/assets/dotnet-interview-prep-guide.pdf" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
+                        <i class="fas fa-download mr-2"></i> Download Your Free Guide
+                    </a>
+                    <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here — a one-time offer just for you 👇</p>
+                </div>
+            </div>
+
+            <!-- Pricing Cards -->
+            <div class="row justify-content-center mb-2">
+                <div class="col-lg-10">
+                    <div class="pricing-grid">
+
+                        <!-- ── Card 1: 3-Course Bundle ── -->
+                        <div class="pricing-card">
+                            <!-- #7 — clearer name that stands on its own -->
+                            <div class="bundle-name">.NET Interview Prep Bundle</div>
+                            <!-- #3 — explicit course count -->
+                            <div class="course-count">3 premium video courses</div>
+                            <div class="price-row">
+                                <span class="price-original">$321</span>
+                                <span class="price-oto"><sup>$</sup>197</span>
+                                <div class="price-note">One-time offer. Not available anywhere else.</div>
+                            </div>
+                            <!-- #1 — fixed height so boxes are visually comparable -->
+                            <img src="images/bootcamp/aspnet-bundle-boxes.png" alt=".NET Interview Prep Bundle" class="bundle-image" style="max-width:75%;">
+                            <a href="https://learn.dotnetacademy.io/enroll/3712862?price_id=4662654&coupon=GUIDE124" class="cta-btn">
+                                Get the Interview Prep Bundle for $197
+                            </a>
+                            <ul class="include-list">
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Essentials</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Advanced</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Security</li>
+                                <li><span class="li-icon" style="color:#4ade80;"><i class="fas fa-code"></i></span> Full source code (.NET 8)</li>
+                                <li><span class="li-icon" style="color:#60a5fa;"><i class="fas fa-closed-captioning"></i></span> Full English captions</li>
+                                <li><span class="li-icon" style="color:#facc15;"><i class="fas fa-book-open"></i></span> Beautifully illustrated handouts</li>
+                                <li><span class="li-icon" style="color:#a78bfa;"><i class="fas fa-certificate"></i></span> Course certificates</li>
+                            </ul>
+                        </div>
+
+                        <!-- ── Card 2: Full Bootcamp ── -->
+                        <div class="pricing-card best-deal">
+                            <div class="best-deal-badge">🏆 Best Value</div>
+                            <div class="bundle-name">.NET Backend Developer Bootcamp</div>
+                            <!-- #3 — explicit course count -->
+                            <div class="course-count">9 premium video courses</div>
+                            <div class="price-row">
+                                <span class="price-original">$497</span>
+                                <span class="price-oto"><sup>$</sup>297</span>
+                                <div class="price-note">One-time offer. Not available anywhere else.</div>
+                            </div>
+                            <img src="images/bootcamp-bundle-boxes.png" alt=".NET Backend Developer Bootcamp" class="bundle-image">
+                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="cta-btn">
+                                Get the Full Bootcamp for $297
+                            </a>
+                            <ul class="include-list">
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Essentials</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Advanced</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Security</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> Azure For .NET Developers</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> Containers &amp; Aspire</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> Payments, Queues &amp; Workers</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> Integration Testing for .NET Developers</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> Azure DevOps CI/CD for .NET Developers</li>
+                                <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> Troubleshooting .NET Apps in Azure</li>
+                                <li><span class="li-icon" style="color:#4ade80;"><i class="fas fa-code"></i></span> Full source code (.NET 8)</li>
+                                <li><span class="li-icon" style="color:#60a5fa;"><i class="fas fa-closed-captioning"></i></span> Full English captions</li>
+                                <li><span class="li-icon" style="color:#facc15;"><i class="fas fa-book-open"></i></span> Beautifully illustrated handouts</li>
+                                <li><span class="li-icon" style="color:#a78bfa;"><i class="fas fa-certificate"></i></span> Course certificates</li>
+                            </ul>
+                        </div>
+
+                    </div><!-- /pricing-grid -->
+                </div>
+            </div>
+
+            <!-- No Thanks (top) -->
+            <div class="no-thanks-wrap">
+                <a href="https://forms.microsoft.com/r/Qe5GefxGXx" target="_blank" class="btn-no-thanks">No Thanks, I don't want a discount</a>
+            </div>
+        </div>
+    </header>
+
+    <!-- ── Feature Cards Section ──────────────────────────── -->
+    <div id="features" class="basic-1" style="padding: 3rem 0 1rem;">
+        <div class="container">
+
+            <p class="section-label">What's Inside</p>
+            <h2 class="section-title">Everything You'll Be Able to Build</h2>
+
+            <!-- #4 — clearer legend with color swatches -->
+            <div class="legend-row">
+                <div class="legend-item">
+                    <div class="legend-swatch both"></div>
+                    <span>Included in <strong style="color:white;">both</strong> bundles</span>
+                </div>
+                <div class="legend-item">
+                    <div class="legend-swatch bootcamp"></div>
+                    <span><strong style="color:#f5a623;">Bootcamp only</strong></span>
+                </div>
+            </div>
+
+            <!-- #5 — all feature cards in ONE row to eliminate empty gaps -->
+            <div class="row">
+
+                <!-- Build Solid REST APIs — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-plug text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Build Solid REST APIs</h5>
+                                <p>Master HTTP verbs, status codes, resource conventions, and build client-friendly APIs with consistent error handling and Minimal APIs.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Vertical Slice Architecture — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-layer-group text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Use Vertical Slice Architecture</h5>
+                                <p>Group everything per feature to reduce coupling, make changes in isolation, and stop touching 6 files just to add one field.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Dependency Injection — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-sitemap text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Stop Hardcoding Dependencies</h5>
+                                <p>Register services once and let ASP.NET Core resolve them automatically, making your code testable and easy to swap.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Entity Framework Core — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-database text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Simplify Data Access with Entity Framework Core</h5>
+                                <p>Map C# classes to database tables, run migrations, and query data with LINQ without writing a single line of SQL.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Async Programming — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-bolt text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Scale with Asynchronous Programming</h5>
+                                <p>Use async/await to keep threads free under load, build non-blocking I/O APIs, and avoid the pitfalls that trip up senior devs.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Logging — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-stream text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Production-Ready Logging</h5>
+                                <p>Implement structured logging with Serilog, write searchable logs, and configure log levels for dev vs production environments.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Middleware — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-filter text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Handle Cross-Cutting Concerns with Middleware</h5>
+                                <p>Build and chain middleware components for auth, logging, rate limiting, and request modification without polluting your handlers.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Error Handling — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-shield-alt text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Global Error Handling</h5>
+                                <p>Centralize exception handling with ProblemDetails, return consistent error responses, and never let stack traces leak to clients.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Pagination & Search — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-search text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Efficient Pagination &amp; Search</h5>
+                                <p>Implement cursor-based and offset pagination, full-text search, and filter patterns that scale without hammering the database.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- File Uploads — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-upload text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Secure File Uploads</h5>
+                                <p>Validate file types, enforce size limits, store files safely, and serve them without exposing direct paths or enabling injection attacks.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- JWT Authentication — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-key text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Secure APIs with JWT Authentication</h5>
+                                <p>Issue and validate JWTs, protect endpoints, handle token expiry, and understand exactly what's inside that Base64 string.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Authorization — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-user-shield text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">ASP.NET Core Authorization</h5>
+                                <p>Implement role-based and policy-based authorization, write custom requirements, and lock down endpoints with granular rules.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Docker — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fab fa-docker text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Containerize Your .NET Apps</h5>
+                                <p>Write Dockerfiles, build images, run containers locally, and push to a registry. That's the prerequisite for every cloud deployment.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Keycloak — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-id-badge text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Professional Identity Management with Keycloak</h5>
+                                <p>Offload login, registration, and MFA to a battle-tested identity server. No more hand-rolling auth from scratch.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- OAuth 2.0 & OIDC — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-lock text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">OAuth 2.0 and OpenID Connect</h5>
+                                <p>Understand the flows that power every modern login button and implement them correctly in your ASP.NET Core APIs and frontends.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Frontends — both -->
+                <div class="col-lg-6">
+                    <div class="benefit-card">
+                        <div class="media">
+                            <i class="fas fa-laptop-code text-white" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Two Frontend Stacks Included</h5>
+                                <p>See your API in action with both a Blazor and a React frontend, with real full-stack context so you understand how .NET backends integrate with modern clients.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ── Bootcamp-only cards — gold left stripe + badge ── -->
+
+                <!-- App Service — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fab fa-microsoft" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Deploy Without the Server Headaches</h5>
+                                <p>Ship to Azure App Service in minutes with slots, auto-scale rules, custom domains, and TLS. No VM management required.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Entra ID — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-users-cog" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Production Identity Management with Entra ID</h5>
+                                <p>Replace your local IdP with Microsoft Entra ID and get enterprise SSO, conditional access, and managed tokens in production.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Azure Storage — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-cloud-upload-alt" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Azure Storage: File Storage Without Limits</h5>
+                                <p>Store user uploads in Blob Storage with SAS tokens, lifecycle policies, and private/public access configurations.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Azure Front Door — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-globe" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Global File Delivery with Azure Front Door</h5>
+                                <p>Put a CDN in front of your storage and APIs for millisecond response times worldwide, with WAF protection included.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Managed Identities — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-fingerprint" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Passwordless Azure Authentication</h5>
+                                <p>Connect your app to Azure services without secrets or passwords using Managed Identities. That's how production systems should work.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- PostgreSQL — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-server" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Production-Grade PostgreSQL Database</h5>
+                                <p>Provision Azure Database for PostgreSQL, connect EF Core, run migrations in CI/CD, and configure connection pooling for scale.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Key Vault — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-lock" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Secure Secret Management with Key Vault</h5>
+                                <p>Move connection strings and API keys out of appsettings.json and into Azure Key Vault. No more secrets in source control.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Container Fundamentals — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-box" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Transform .NET Apps Into Bulletproof Containers</h5>
+                                <p>Multi-stage builds, non-root users, image size optimization: production Docker patterns that actually matter.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Azure Container Apps — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-cloud" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Production Containers with Azure Container Apps</h5>
+                                <p>Deploy containers to Azure without managing Kubernetes, with built-in KEDA scaling, Dapr support, and per-revision traffic splitting.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Health Checks — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-heartbeat" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Build Self-Healing APIs</h5>
+                                <p>Add liveness and readiness health checks so containers self-heal, load balancers reroute, and on-call pages stay quiet.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Aspire Tracing — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-chart-line" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Debug Performance Issues with Aspire Tracing</h5>
+                                <p>Visualize distributed traces across services, spot N+1 queries, and find latency bottlenecks before they hit production.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Infrastructure as Code — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-code-branch" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Define Your Entire System in C#</h5>
+                                <p>Use .NET Aspire to declare your full cloud architecture in C#, from databases to message buses, and deploy it reproducibly.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Aspire Orchestration — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-project-diagram" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Map Your Architecture Visually with .NET Aspire</h5>
+                                <p>Orchestrate microservices, see dependencies in a dashboard, and run the entire system locally with one command.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Bicep — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-tools" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Advanced Infrastructure-as-Code with Bicep</h5>
+                                <p>Write repeatable Azure infrastructure in Bicep, parameterize environments, and deploy everything through a single pipeline.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Stripe Payments — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-credit-card" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Accept Secure Payments with Stripe</h5>
+                                <p>Integrate Stripe Checkout, handle webhooks for fulfillment, manage subscriptions, and pass PCI compliance without reinventing the wheel.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Webhooks — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-broadcast-tower" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Instant Notifications with Webhooks</h5>
+                                <p>Build and consume webhooks reliably: signature validation, retry logic, idempotency, and processing events from external systems.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Transactions — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-sync-alt" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Ensure Data Consistency with Transactions</h5>
+                                <p>Implement database transactions, the outbox pattern, and saga coordination so partial failures never leave data in a broken state.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Queues & Workers — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-cogs" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Scale Safely with Queues and Workers</h5>
+                                <p>Offload slow work to background queues, build resilient worker services, and handle dead-letter messages without data loss.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Integration Testing — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-vial" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Integration Tests That Actually Work</h5>
+                                <p>Spin up real databases with Testcontainers, test the full HTTP stack, and write tests that catch production bugs before deployment.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Azure DevOps CI/CD — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-rocket" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Azure DevOps CI/CD for .NET Developers</h5>
+                                <p>Build full Azure Pipelines with build, test, Docker publish, and multi-environment Azure deployment. Enterprise-grade from day one.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Troubleshooting — bootcamp -->
+                <div class="col-lg-6">
+                    <div class="benefit-card bootcamp-only">
+                        <span class="bootcamp-tag">Bootcamp Only</span>
+                        <div class="media">
+                            <i class="fas fa-bug" style="font-size:1.2rem;margin-right:1rem;margin-top:0.15rem;flex-shrink:0;color:#f5a623;"></i>
+                            <div class="media-body">
+                                <h5 class="font-weight-bold">Troubleshoot .NET Apps in Azure</h5>
+                                <p>Diagnose crashes, memory leaks, and slow APIs in production using Azure Monitor, Log Analytics, Application Insights, and remote debugging.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div><!-- /row: all feature cards -->
+        </div><!-- /container -->
+    </div><!-- /features -->
+
+    <!-- ── Bottom CTA Section ─────────────────────────────── -->
+    <div class="basic-1" style="padding: 2rem 0 1rem;">
+        <div class="container">
+            <div class="row justify-content-center mb-2">
+                <div class="col-lg-10">
+                    <!-- #6 — proper card wrappers + custom btn class, no overflow -->
+                    <div class="pricing-grid">
+
+                        <!-- 3-Course Bundle CTA -->
+                        <div class="bottom-cta-card">
+                            <div class="text-white mb-1" style="font-size:1.1rem;font-weight:700;">.NET Interview Prep Bundle</div>
+                            <div class="course-count" style="text-align:center;margin-bottom:0.75rem;">3 premium video courses</div>
+                            <div style="margin-bottom:0.75rem;">
+                                <span style="color:rgba(255,255,255,0.45);text-decoration:line-through;margin-right:0.4rem;font-size:0.95rem;">$321</span>
+                                <span style="color:white;font-size:1.7rem;font-weight:800;">$197</span>
+                            </div>
+                            <a href="https://learn.dotnetacademy.io/enroll/3712862?price_id=4662654&coupon=GUIDE124" class="bottom-cta-btn">
+                                Get the Interview Prep Bundle for $197
+                            </a>
+                        </div>
+
+                        <!-- Bootcamp CTA -->
+                        <div class="bottom-cta-card best-deal">
+                            <div class="text-white mb-1" style="font-size:1.1rem;font-weight:700;">.NET Backend Developer Bootcamp</div>
+                            <div style="margin-bottom:0.25rem;"><span style="background:linear-gradient(45deg,#f5a623,#f0860a);color:white;font-size:0.68rem;font-weight:700;padding:0.2rem 0.7rem;border-radius:8px;">🏆 Best Value</span></div>
+                            <div class="course-count" style="text-align:center;margin-bottom:0.75rem;">9 premium video courses</div>
+                            <div style="margin-bottom:0.75rem;">
+                                <span style="color:rgba(255,255,255,0.45);text-decoration:line-through;margin-right:0.4rem;font-size:0.95rem;">$497</span>
+                                <span style="color:white;font-size:1.7rem;font-weight:800;">$297</span>
+                            </div>
+                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="bottom-cta-btn gold">
+                                Get the Full Bootcamp for $297
+                            </a>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+            <!-- No Thanks (bottom) -->
+            <div class="no-thanks-wrap">
+                <a href="https://forms.microsoft.com/r/Qe5GefxGXx" target="_blank" class="btn-no-thanks">No Thanks, I don't want a discount</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Copyright -->
+    <div class="copyright">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12">
+                    <p class="p-small">Copyright © 2026 Julio Casal LLC</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="js/favicon.js"></script>
+</body>
+
+</html>

--- a/interview-guide-sent-subscribers.html
+++ b/interview-guide-sent-subscribers.html
@@ -423,7 +423,7 @@
                     <h2 class="text-white mb-4" style="font-size: 1.65rem; font-weight: 400; opacity: 0.9;">
                         125 essential questions for Senior &amp; Staff .NET interviews — with complete answers.
                     </h2>
-                    <a href="https://juliocasal.com/assets/dotnet-interview-prep-guide.pdf" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
+                    <a href="https://attachments.convertkitcdnn2.com/645794/271c87b3-12ca-4c0c-b70d-0e5caadc87ed/the-dot-net-interview-prep-guide.pdf" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
                         <i class="fas fa-download mr-2"></i> Download Your Free Guide
                     </a>
                     <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here — a one-time offer just for you 👇</p>

--- a/interview-guide-sent-subscribers.html
+++ b/interview-guide-sent-subscribers.html
@@ -423,7 +423,7 @@
                     <h2 class="text-white mb-4" style="font-size: 1.65rem; font-weight: 400; opacity: 0.9;">
                         125 essential questions for Senior &amp; Staff .NET interviews — with complete answers.
                     </h2>
-                    <a href="https://attachments.convertkitcdnn2.com/645794/271c87b3-12ca-4c0c-b70d-0e5caadc87ed/the-dot-net-interview-prep-guide.pdf" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
+                    <a href="https://attachments.convertkitcdnn2.com/645794/271c87b3-12ca-4c0c-b70d-0e5caadc87ed/the-dot-net-interview-prep-guide.pdf?utm_campaign=Interview+Guide+Broadcast&utm_medium=email&utm_source=kit" target="_blank" class="btn-solid-lg mb-2" style="font-size: 1.1rem; padding: 0.9rem 2.5rem; display: inline-block;">
                         <i class="fas fa-download mr-2"></i> Download Your Free Guide
                     </a>
                     <p class="text-white mt-3" style="opacity: 0.6; font-size: 0.95rem;">And while you're here — a one-time offer just for you 👇</p>


### PR DESCRIPTION
## What this adds

New page `/interview-guide-download` — a variant of the thank-you + OTO page designed for **existing subscribers** sent the guide via broadcast email.

## Difference from `/interview-guide-sent`

| | `/interview-guide-sent` | `/interview-guide-download` |
|---|---|---|
| Entry point | Kit form submission (new leads) | Broadcast email CTA link (existing subscribers) |
| Hero | "On Its Way!" (email delivery) | "Is Here!" (immediate access) |
| Download | Guide delivered via Kit email sequence | Direct PDF download button at top of page |
| OTO section | Same | Same (pricing cards, feature grid, No Thanks) |

## Page flow
1. Subscriber clicks CTA in broadcast email → lands on `/interview-guide-download`
2. "Download Your Free Guide" button → Kit CDN PDF link (opens in new tab)
3. OTO pricing cards, feature grid, No Thanks buttons — identical to `/interview-guide-sent`

## Broadcast email CTA URL
`https://juliocasal.com/interview-guide-download`

## PDF download link
Kit CDN attachment URL with UTM params:
- `utm_campaign=Interview+Guide+Broadcast`
- `utm_medium=email`
- `utm_source=kit`

This URL is permanent (Kit CDN does not time-expire attachment links). Used for one-time broadcast only — future lead magnet traffic continues through the standard `/interview` → `/interview-guide-sent` funnel.