### PR TITLE
feat: update bootcamp OTO price to $347 (save $150, coupon GUIDE150)

### DIFF
--- a/interview-guide-download.html
+++ b/interview-guide-download.html
@@ -470,12 +470,12 @@
                             <div class="course-count">9 premium video courses</div>
                             <div class="price-row">
                                 <span class="price-original">$497</span>
-                                <span class="price-oto"><sup>$</sup>297</span>
+                                <span class="price-oto"><sup>$</sup>347</span>
                                 <div class="price-note">Offer expires <span style="color: #f5a623; font-weight: 600;">Sunday, March 22 at midnight.</span></div>
                             </div>
                             <img src="images/bootcamp-bundle-boxes.png" alt=".NET Backend Developer Bootcamp" class="bundle-image">
-                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="cta-btn">
-                                Get the Full Bootcamp for $297
+                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE150" class="cta-btn">
+                                Get the Full Bootcamp for $347
                             </a>
                             <ul class="include-list">
                                 <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Essentials</li>
@@ -1060,10 +1060,10 @@
                             <div class="course-count" style="text-align:center;margin-bottom:0.75rem;">9 premium video courses</div>
                             <div style="margin-bottom:0.75rem;">
                                 <span style="color:rgba(255,255,255,0.45);text-decoration:line-through;margin-right:0.4rem;font-size:0.95rem;">$497</span>
-                                <span style="color:white;font-size:1.7rem;font-weight:800;">$297</span>
+                                <span style="color:white;font-size:1.7rem;font-weight:800;">$347</span>
                             </div>
-                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="bottom-cta-btn gold">
-                                Get the Full Bootcamp for $297
+                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE150" class="bottom-cta-btn gold">
+                                Get the Full Bootcamp for $347
                             </a>
                             <div style="font-size:0.78rem;color:rgba(255,255,255,0.5);margin-top:0.6rem;">Offer expires <span style="color:#f5a623;font-weight:600;">Sunday, March 22 at midnight.</span></div>
                         </div>

--- a/interview-guide-sent.html
+++ b/interview-guide-sent.html
@@ -466,12 +466,12 @@
                             <div class="course-count">9 premium video courses</div>
                             <div class="price-row">
                                 <span class="price-original">$497</span>
-                                <span class="price-oto"><sup>$</sup>297</span>
+                                <span class="price-oto"><sup>$</sup>347</span>
                                 <div class="price-note">One-time offer. Not available anywhere else.</div>
                             </div>
                             <img src="images/bootcamp-bundle-boxes.png" alt=".NET Backend Developer Bootcamp" class="bundle-image">
-                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="cta-btn">
-                                Get the Full Bootcamp for $297
+                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE150" class="cta-btn">
+                                Get the Full Bootcamp for $347
                             </a>
                             <ul class="include-list">
                                 <li><span class="li-icon" style="color:#818cf8;"><i class="fas fa-video"></i></span> ASP.NET Core Essentials</li>
@@ -1059,10 +1059,10 @@
                             <div class="course-count" style="text-align:center;margin-bottom:0.75rem;">9 premium video courses</div>
                             <div style="margin-bottom:0.75rem;">
                                 <span style="color:rgba(255,255,255,0.45);text-decoration:line-through;margin-right:0.4rem;font-size:0.95rem;">$497</span>
-                                <span style="color:white;font-size:1.7rem;font-weight:800;">$297</span>
+                                <span style="color:white;font-size:1.7rem;font-weight:800;">$347</span>
                             </div>
-                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE200" class="bottom-cta-btn gold">
-                                Get the Full Bootcamp for $297
+                            <a href="https://learn.dotnetacademy.io/enroll/3631037?price_id=4570881&coupon=GUIDE150" class="bottom-cta-btn gold">
+                                Get the Full Bootcamp for $347
                             </a>
                         </div>
 


### PR DESCRIPTION
## Changes

Updates bootcamp pricing on both OTO pages:

| | Before | After |
|---|---|---|
| Bootcamp price | $297 | $347 |
| Savings | $200 off | $150 off |
| Coupon | GUIDE200 | GUIDE150 |
| Bundle price | $197 | $197 (unchanged) |
| Bundle coupon | GUIDE124 | GUIDE124 (unchanged) |

## Files changed
- `interview-guide-sent.html` — cold leads via form submission
- `interview-guide-download.html` — existing subscribers via broadcast email

## Action required before merging
- Create coupon `GUIDE150` in payment platform (30% off / $150 off bootcamp, expires Sunday March 22)
- Deactivate or repurpose `GUIDE200` if no longer needed